### PR TITLE
Fix warning about unhandled files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,12 @@ let package = Package(
     targets: 
     [
         .target(          name: "JPEG",                                           path: "sources/jpeg"),
-        .executableTarget(name: "JPEGFuzzer",             dependencies: ["JPEG"], path: "tests/fuzz"),
+        .executableTarget(name: "JPEGFuzzer",             dependencies: ["JPEG"], path: "tests/fuzz",
+            exclude:
+            [
+                "data/",
+            ]
+        ),
         .executableTarget(name: "JPEGComparator",         dependencies: ["JPEG"], path: "tests/compare"),
         .executableTarget(name: "JPEGUnitTests",          dependencies: ["JPEG"], path: "tests/unit"),
         .executableTarget(name: "JPEGRegressionTests",    dependencies: ["JPEG"], path: "tests/regression",


### PR DESCRIPTION
Fix warning:
```
warning: 'jpeg': found 32 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users*****jpeg/tests/fuzz/data/3.jpg
    /Users*****jpeg/tests/fuzz/data/9.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/1.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/11.jpg
    /Users*****jpeg/tests/fuzz/data/12.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/1.jpg
    /Users*****jpeg/tests/fuzz/data/5.jpg
    /Users*****jpeg/tests/fuzz/data/8.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/9.jpg
    /Users*****jpeg/tests/fuzz/data/11.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/6.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/15.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/12.jpg
    /Users*****jpeg/tests/fuzz/data/3.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/5.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/10.jpg
    /Users*****jpeg/tests/fuzz/data/6.jpg
    /Users*****jpeg/tests/fuzz/data/15.jpg
    /Users*****jpeg/tests/fuzz/data/0.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/14.jpg
    /Users*****jpeg/tests/fuzz/data/13.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/13.jpg
    /Users*****jpeg/tests/fuzz/data/7.jpg
    /Users*****jpeg/tests/fuzz/data/8.jpg
    /Users*****jpeg/tests/fuzz/data/4.jpg
    /Users*****jpeg/tests/fuzz/data/14.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/4.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/2.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/7.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/10.jpg.ycc
    /Users*****jpeg/tests/fuzz/data/2.jpg
    /Users*****jpeg/tests/fuzz/data/0.jpg
```