### PR TITLE
Fix some structured concurrency warnings

### DIFF
--- a/sources/common/output.swift
+++ b/sources/common/output.swift
@@ -14,9 +14,9 @@ extension String
 enum Highlight 
 {
     static 
-    var bold:String     = "\u{1B}[1m"
-    static 
-    var reset:String    = "\u{1B}[0m"
+    let bold:String     = "\u{1B}[1m"
+    static
+    let reset:String    = "\u{1B}[0m"
     
     static 
     func fg(_ color:(r:UInt8, g:UInt8, b:UInt8)?) -> String 

--- a/sources/jpeg/jpeg.swift
+++ b/sources/jpeg/jpeg.swift
@@ -616,12 +616,12 @@ extension JPEG
     /// # [Coding processes](coding-processes)
     /// ## (4:lexing-and-formatting)
     public 
-    enum Process 
+    enum Process:Sendable
     {
         /// enum JPEG.Process.Coding 
         ///     An entropy coding method.
         public 
-        enum Coding 
+        enum Coding:Sendable
         {
             /// case JPEG.Process.Coding.huffman
             ///     Huffman entropy coding.

--- a/sources/jpeg/jpeg.swift
+++ b/sources/jpeg/jpeg.swift
@@ -1057,7 +1057,7 @@ extension JPEG
             /// enum JPEG.Table.Quantization.Precision 
             ///     The integer width of the quantum values in this quantization table.
             public 
-            enum Precision  
+            enum Precision:Sendable
             {
                 /// case JPEG.Table.Quantization.Precision.uint8 
                 ///     The quantum values are encoded as 8-bit unsigned integers.

--- a/sources/jpeg/jpeg.swift
+++ b/sources/jpeg/jpeg.swift
@@ -681,7 +681,7 @@ extension JPEG
     ///     A marker type indicator.
     /// ## (3:lexing-and-formatting)
     public 
-    enum Marker
+    enum Marker:Sendable
     {
         /// case JPEG.Marker.start 
         ///     A start-of-image (SOI) marker.

--- a/sources/jpeg/jpeg.swift
+++ b/sources/jpeg/jpeg.swift
@@ -1034,7 +1034,7 @@ extension JPEG
             /// ## (key-types)
             /// ## (0:image-quality)
             public 
-            struct Key:Hashable, Comparable  
+            struct Key:Hashable, Comparable, Sendable
             {
                 let value:Int 
                 
@@ -1104,7 +1104,7 @@ extension JPEG
         /// ## (key-types)
         /// ## (2:image-structure-and-decomposition)
         public 
-        struct Key:Hashable, Comparable 
+        struct Key:Hashable, Comparable, Sendable
         {
             let value:Int 
             


### PR DESCRIPTION
Fix some structured concurrency warnings by conforming types to `Sendable` and making `var`'s `let`'s.
This still leaves some warnings with `WritableKeyPath`'s and with `CommandLine.arguments`. Last - in tests.
Probably, sendability of `WritableKeyPath` will be inferred with [Inferring Sendable for methods and key path literals](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md).