### PR TITLE
[patch]: Fix build on Android ARMv7 (32-bit)

### DIFF
--- a/Sources/JPEGSystem/os.swift
+++ b/Sources/JPEGSystem/os.swift
@@ -133,7 +133,7 @@ extension System.File.Source {
             return nil
         }
 
-        switch status.st_mode & S_IFMT {
+        switch mode_t(status.st_mode) & S_IFMT {
         case S_IFREG, S_IFLNK:
             break
         default:

--- a/Sources/JPEGSystem/os.swift
+++ b/Sources/JPEGSystem/os.swift
@@ -133,7 +133,8 @@ extension System.File.Source {
             return nil
         }
 
-        switch mode_t(status.st_mode) & S_IFMT {
+        // on android-armv7, `mode_t` is `UInt16`
+        switch mode_t.init(status.st_mode) & S_IFMT {
         case S_IFREG, S_IFLNK:
             break
         default:


### PR DESCRIPTION
After updating to 2.1.0, building form android-armv7 failed with
`error: binary operator '&' cannot be applied to operands of type 'UInt32' and 'mode_t' (aka 'UInt16')`